### PR TITLE
Remove padding from banner for chips

### DIFF
--- a/dashboard/src/App.vue
+++ b/dashboard/src/App.vue
@@ -24,7 +24,7 @@
           </v-col>
         </v-row>
         <v-toolbar-title class="mt-3 headline">Afgelopen 24u</v-toolbar-title>
-        <v-banner sticky app>
+        <v-banner sticky app class="chip-banner">
           <v-chip small label close dark v-for="s in selectedStations" :key="s.id" class="ma-1" :color="legendColors[s.id]" v-on:click:close="removeFromList(s.id)">
             {{ s.given_name }}
           </v-chip>
@@ -134,3 +134,9 @@ export default class App extends Vue {
   }
 }
 </script>
+
+<style>
+  .chip-banner .v-banner__wrapper {
+    padding: 0 !important;
+  }
+</style>


### PR DESCRIPTION
I added a new class to the banner-container and then targetted `.chips-banner .v-banner__wrapper` to remove the padding from around the banner. This results in something like this:

![image](https://user-images.githubusercontent.com/9608686/85021908-d075f180-b172-11ea-884f-104f64f426df.png)
