### PR TITLE
Add WBGT values to API

### DIFF
--- a/api/Gemfile
+++ b/api/Gemfile
@@ -19,3 +19,5 @@ gem "csv", "~> 3.2"
 gem "byebug", "~> 11.1", :group => :development
 
 gem "rom-sql", "~> 3.5"
+
+gem "puma", "~> 5.6", :group => :development

--- a/api/Gemfile.lock
+++ b/api/Gemfile.lock
@@ -34,6 +34,9 @@ GEM
     mustermann (1.1.1)
       ruby2_keywords (~> 0.0.1)
     mysql2 (0.5.4)
+    nio4r (2.5.8)
+    puma (5.6.4)
+      nio4r (~> 2.0)
     rack (2.2.3.1)
     rack-protection (2.2.0)
       rack
@@ -88,6 +91,7 @@ DEPENDENCIES
   csv (~> 3.2)
   json (~> 2.6)
   mysql2 (~> 0.5.4)
+  puma (~> 5.6)
   rom-sql (~> 3.5)
   sinatra (~> 2.2)
   sinatra-contrib (~> 2.2)

--- a/api/app.rb
+++ b/api/app.rb
@@ -61,7 +61,7 @@ end
 #
 
 class Vlinder < ROM::Relation[:sql]
-  schema :Vlinder, infer: true, as: :vlinder do
+  schema :Vlinder_Combined_Dashboard, infer: true, as: :vlinder do
     attribute :StationID, Types::String
   end
 
@@ -161,7 +161,8 @@ class Vlinder < ROM::Relation[:sql]
         time: current[:datetime].strftime(DATETIME_FMT),
         windDirection: current[:WindDirection].to_f.round(2),
         windGust: current[:WindGust].to_f.round(2),
-        windSpeed: current[:WindSpeed].to_f.round(2)
+        windSpeed: current[:WindSpeed].to_f.round(2),
+        wbgt: current[:wet_bulb_globe_temp] ? current[:wet_bulb_globe_temp].to_f.round(2) : nil
       }
     end
   end


### PR DESCRIPTION
This PR adds the WBGT value to the API where available. If the value is not available for a station, `null` is returned.