### PR TITLE
fix(dashboard): drop deprecated baseUrl for TypeScript 6

### DIFF
--- a/dashboard/src/vite-env.d.ts
+++ b/dashboard/src/vite-env.d.ts
@@ -10,3 +10,5 @@ declare module '*.vue' {
 declare module 'vuetify'
 declare module 'vuetify/lib/components'
 declare module 'vuetify/lib/directives'
+// Resolves to a .css file, which TS 6 refuses to side-effect import without a declaration
+declare module 'vuetify/styles'

--- a/dashboard/tsconfig.json
+++ b/dashboard/tsconfig.json
@@ -1,7 +1,5 @@
 {
   "compilerOptions": {
-    "ignoreDeprecations": "5.0",
-    "baseUrl": ".",
     "target": "ESNext",
     "useDefineForClassFields": true,
     "module": "ESNext",
@@ -17,7 +15,7 @@
     "noEmit": true,
     "paths": {
       "@/*": [
-       "src/*"
+       "./src/*"
       ]
      }
   },

--- a/dashboard/tsconfig.node.json
+++ b/dashboard/tsconfig.node.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "ignoreDeprecations": "5.0",
     "composite": true,
     "module": "ESNext",
     "moduleResolution": "bundler",


### PR DESCRIPTION
Unblocks #1246 (typescript 5.5.4 → 6.0.3), whose `build` check currently fails before compiling a single file:

```
tsconfig.json(4,5): error TS5101: Option 'baseUrl' is deprecated and will stop
functioning in TypeScript 7.0. Specify compilerOption '"ignoreDeprecations": "6.0"'
to silence this error.
```

## What changed

- **Dropped `baseUrl` and the `ignoreDeprecations` waivers** from both tsconfigs. Bumping the waiver to `"6.0"` would also work, but only until TS 7 removes `baseUrl` outright. Since TS 4.1, `paths` resolve relative to the tsconfig's own directory, so the mapping keeps working once it gets a leading `./` — otherwise TS5090. No source file relied on `baseUrl` for bare-specifier resolution; every import is either relative, `@/…`, or a real package.
- **Declared `vuetify/styles`.** A second TS 6 breakage that was hidden behind the first: TS 6 raises TS2882 for side-effect imports with no type declarations, and `vuetify/styles` resolves through the export map to a `.css` file. (`@mdi/font/…​.css` is fine — the literal `.css` extension matches vite/client's ambient `*.css` module.)

## Verification

`vue-tsc --noEmit`, `vitest` (17 tests) and `vite build` all pass locally against **both** typescript 5.5.4 and 6.0.3.

After this merges, #1246 still needs a `@dependabot recreate` — it has been open long enough that automatic rebases were disabled, and it now conflicts with master on `package.json`/`yarn.lock`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)