### PR TITLE
Group minor and patch Dependabot updates per ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,10 @@ updates:
       update-types:
       - minor
       - patch
+      exclude-patterns:
+      - "vue"
+      - "vuetify"
+      - "d3"
 - package-ecosystem: bundler
   directory: "/api"
   schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,15 +6,30 @@ updates:
     interval: monthly
     time: "04:00"
   open-pull-requests-limit: 10
+  groups:
+    minor-and-patch:
+      update-types:
+      - minor
+      - patch
 - package-ecosystem: bundler
   directory: "/api"
   schedule:
     interval: monthly
     time: "04:00"
   open-pull-requests-limit: 10
+  groups:
+    minor-and-patch:
+      update-types:
+      - minor
+      - patch
 - package-ecosystem: github-actions
   directory: "/"
   schedule:
     interval: monthly
     time: "04:00"
   open-pull-requests-limit: 10
+  groups:
+    minor-and-patch:
+      update-types:
+      - minor
+      - patch


### PR DESCRIPTION
This pull request adds a `minor-and-patch` group to each ecosystem in `.github/dependabot.yml` (npm, bundler, github-actions) so routine minor/patch updates land as a single combined PR per ecosystem instead of one PR per dependency. Major version bumps are left ungrouped and continue to open as individual PRs, since those need manual review.

The npm group additionally excludes the runtime-critical `vue`, `vuetify`, and `d3` packages via `exclude-patterns`, so those keep arriving as individual PRs even for minor/patch bumps.

Schedule and other existing settings are unchanged.

**Manual testing instructions**
- n/a (config-only change; validated the YAML parses correctly with `yaml.safe_load`)

**Checklist**
- Tests: n/a
- Docs: n/a
- Announcement: n/a
- AI: Claude Code wrote and validated the config change