### PR TITLE
Slim code comments down to repo style

### DIFF
--- a/api/app.rb
+++ b/api/app.rb
@@ -26,9 +26,7 @@ UPDATE_INTERVAL = 300
 LOOKBACK_UPDATES = 3
 DATETIME_FMT = '%a, %d %b %Y %H:%M:%S %Z'
 DB_MAX_RETRIES = 3
-# How long clients may treat a response as fresh without revalidating. Kept well
-# under UPDATE_INTERVAL so clients still pick up new data promptly, while
-# avoiding a revalidation round-trip on every single request.
+# how long clients may reuse a response without revalidating
 CACHE_MAX_AGE = UPDATE_INTERVAL / 5
 
 # vlinder database uses UTC, and we want to respond with UTC,
@@ -74,10 +72,7 @@ class Vlinder < ROM::Relation[:sql]
   def retry_until_succeeded(&block)
     tries = 0
     begin
-      # Dispatch on the current $vlinder (rather than plain `yield`/`self`) so
-      # that if a previous iteration reconnected below, this attempt actually
-      # runs against the fresh connection instead of the dead one `self` was
-      # bound to when this method was first called.
+      # run against the current $vlinder so a reconnect takes effect on retry
       $vlinder.instance_exec(&block)
     rescue Sequel::DatabaseConnectionError, Sequel::DatabaseDisconnectError => e
       tries += 1
@@ -105,10 +100,7 @@ class Vlinder < ROM::Relation[:sql]
     end
 
     {
-      # results.last is nil when the lookback window has no rows yet (e.g. a
-      # slow/catching-up MQTT feed) - safe-navigate instead of crashing, so
-      # cache_fetch actually gets a chance to see (and not cache) an empty
-      # result instead of every request 500ing.
+      # results.last is nil when the lookback window has no rows yet
       last_modified: results.last&.[](:datetime),
       data: results.group_by { |data| data[:StationID] }
                    .map { |_id, data| process(data, normalize_rain: false).last }
@@ -127,8 +119,6 @@ class Vlinder < ROM::Relation[:sql]
     end
 
     {
-      # Same as #all_stations: an empty result set for this station/range
-      # must produce data: [] and last_modified: nil, not a crash.
       last_modified: results.last&.[](:datetime),
       data: process(results)
     }
@@ -249,10 +239,7 @@ def reconnect_database
   opts = JSON.parse(File.read(DB_CONFIG_FILE)).transform_keys(&:to_sym)
   opts[:connect_timeout] = 10
   opts[:adapter] = :mysql2
-  # Puma (in the Gemfile) is only used for local development; production runs
-  # under Passenger/Apache, which manages its own worker processes rather than
-  # threads within a single process, so a single-connection pool per process
-  # is intentional here, not an oversight.
+  # production runs multi-process under Passenger; Puma is dev-only
   opts[:max_connections] = 1
 
   conf = ROM::Configuration.new(:sql, opts)
@@ -268,23 +255,11 @@ end
 $station_info, $station_info_last_modified = read_stations
 $vlinder = reconnect_database unless ENV['RACK_ENV'] == 'test'
 $cache = Hash.new { |hash, key| hash[key] = {} }
-# $cache is a plain Hash shared by every request-handling thread; guard its
-# read-check-write cycle with a mutex so concurrent requests can't race each
-# other (e.g. both deciding the cache is stale and both fetching/writing).
 $cache_mutex = Mutex.new
 
-# Fetches the cached value living at $cache[path[0]][path[1]]... (e.g.
-# cache_fetch(:measurements) or cache_fetch(:stations, id)), refreshing it by
-# calling the block when stale.
-#
-# Crucially, a freshly-fetched value is only written back to the cache when
-# it actually contains data. If the MQTT feed is slow/behind, a fetch can
-# legitimately come back with an empty result; caching that would mark the
-# cache "fresh" (via its last_modified) and serve the empty result to every
-# user until the next UPDATE_INTERVAL rolls around. Instead we keep serving
-# the last known-good cached value (or the empty result, if nothing has ever
-# been cached yet) and leave the cache stale, so the very next request
-# retries instead of getting stuck.
+# Fetches $cache[*path], refreshing it via the block when stale. Empty results
+# are served but never cached, so a lagging feed can't pin "no data" for a
+# whole UPDATE_INTERVAL.
 def cache_fetch(*path)
   $cache_mutex.synchronize do
     container = path[0..-2].reduce($cache) { |hash, key| hash[key] ||= {} }
@@ -295,9 +270,7 @@ def cache_fetch(*path)
 
     fresh = yield
     if fresh[:data].nil? || fresh[:data].empty?
-      # Don't poison the cache with an empty result, but if there's nothing
-      # better cached yet (e.g. right after boot), still answer this request
-      # with the accurate (empty) result rather than nothing at all.
+      # serve the empty result if nothing better was ever cached
       current[:data].nil? ? fresh : current
     else
       container[key] = fresh
@@ -340,9 +313,7 @@ get '/measurements/?' do
   result = cache_fetch(:measurements) { $vlinder.all_stations }
 
   if result[:data].nil? || result[:data].empty?
-    # An empty payload must not be cached by anything upstream either -
-    # override the before-filter's public/max-age with no-store, and don't
-    # hand out a (nil) Last-Modified as a validator for it.
+    # empty payloads must not be cached upstream
     cache_control :no_store
   else
     last_modified result[:last_modified]

--- a/api/spec/app_spec.rb
+++ b/api/spec/app_spec.rb
@@ -3,11 +3,7 @@ require 'spec_helper'
 RSpec.describe 'Vlinder API' do
   let(:mock_vlinder) { double('Vlinder Relation') }
 
-  # Builds a fake DB row hash shaped like what the mysql2/rom-sql adapter
-  # would hand to Vlinder#process (mirrors spec/vlinder_spec.rb's helper).
-  # Used to drive the REAL Vlinder#all_stations/#station by stubbing out only
-  # the DB query layer (#retry_until_succeeded), so tests exercise the actual
-  # last_modified/data-shaping logic instead of a hand-rolled return shape.
+  # a row hash shaped like what the rom-sql adapter hands to #process
   def row(overrides = {})
     {
       StationID: 'station1',
@@ -94,11 +90,6 @@ RSpec.describe 'Vlinder API' do
       # Or just clear cache
       $cache[:measurements] = { last_modified: Time.now - 1000, data: [] }
 
-      # We need to ensure updated_since? returns true.
-      # In app.rb: updated_since?(last_modified) checks if Time.now - UPDATE_INTERVAL > last_modified
-      # UPDATE_INTERVAL is 300.
-      # So if last_modified is old enough.
-
       get '/measurements'
       expect(last_response).to be_ok
       json_response = JSON.parse(last_response.body)
@@ -108,18 +99,8 @@ RSpec.describe 'Vlinder API' do
     end
 
     it 'does not stick an empty first fetch to the cache for the whole update window' do
-      # Regression test: if the MQTT feed is slow, the very first fetch after
-      # boot (or after the cache goes stale) can legitimately come back
-      # empty. That must not get cached - otherwise every request for the
-      # rest of UPDATE_INTERVAL would keep being served "no data" even once
-      # real data becomes available.
-      #
-      # This drives the REAL Vlinder#all_stations (via $vlinder being a real,
-      # allocated Vlinder instance) rather than stubbing all_stations itself
-      # with a return shape the real method could never produce - only the DB
-      # query layer (#retry_until_succeeded) is stubbed, with zero rows on
-      # the first call and one real row on the second.
-      $cache[:measurements] = {} # start from a completely empty/stale cache
+      # a slow feed can return an empty first fetch; it must not get cached
+      $cache[:measurements] = {}
 
       real_vlinder = Vlinder.allocate
       allow(real_vlinder).to receive(:retry_until_succeeded).and_return(

--- a/api/spec/vlinder_spec.rb
+++ b/api/spec/vlinder_spec.rb
@@ -1,18 +1,11 @@
 require 'spec_helper'
 
-# These specs exercise the real business logic in Vlinder (changed?, rain_delta,
-# process) directly, instead of going through the mocked $vlinder double used
-# by spec/app_spec.rb. Vlinder < ROM::Relation[:sql] normally needs a live DB
-# connection to build its dataset/schema (see reconnect_database in app.rb),
-# but none of the methods under test touch the dataset or schema at all - they
-# are pure transformations over plain row hashes. So we use Vlinder.allocate
-# to get an instance without running ROM's initializer, and call the private
-# methods via #send. No changes to app.rb were needed for this.
+# The methods under test never touch the dataset/schema, so Vlinder.allocate
+# skips ROM's DB-backed initializer and no live DB is needed.
 RSpec.describe Vlinder do
   subject(:vlinder) { described_class.allocate }
 
-  # Builds a fake DB row hash shaped like what the mysql2/rom-sql adapter
-  # would hand to Vlinder#process (see the `data:` hash built in #process).
+  # a row hash shaped like what the rom-sql adapter hands to #process
   def row(overrides = {})
     {
       StationID: 'station1',
@@ -138,10 +131,7 @@ RSpec.describe Vlinder do
 
       statuses = vlinder.send(:process, measurements).map { |m| m[:status] }
 
-      # index 0: baseline (compared against itself) -> Ok
-      # index 1,2: still unchanged, no_changes climbs to 1, 2 -> Ok
-      # index 3: no_changes reaches LOOKBACK_UPDATES (3) -> Offline
-      # index 4: still unchanged -> stays Offline
+      # flips to Offline once no_changes reaches LOOKBACK_UPDATES (3)
       expect(statuses).to eq(%w[Ok Ok Ok Offline Offline])
     end
 
@@ -194,10 +184,7 @@ RSpec.describe Vlinder do
     end
   end
 
-  # #all_stations and #station are public and call #retry_until_succeeded
-  # (which normally runs a real where/order/to_a query chain). Stubbing that
-  # one method lets these run for real against a canned result set, without
-  # needing a live DB connection - same technique as spec/app_spec.rb.
+  # stubbing the query layer lets the real methods run without a live DB
   describe '#all_stations' do
     it 'returns an empty, non-crashing result when the lookback window has no rows yet' do
       allow(vlinder).to receive(:retry_until_succeeded).and_return([])

--- a/dashboard/e2e/smoke.spec.ts
+++ b/dashboard/e2e/smoke.spec.ts
@@ -8,19 +8,8 @@ import {
 } from '../src/tests/fixtures';
 
 /**
- * End-to-end smoke test against the real built app (vite preview), running
- * in a real Chromium browser. This is the layer that actually exercises d3
- * rendering (mocked out in the vitest smoke test) and catches anything that
- * only manifests once real Vuetify CSS/components/icons/fonts are loaded
- * from the real production bundle - eg. a Vuetify major version bump that
- * changes a component's DOM/class output enough to break layout, even if it
- * doesn't emit a Vue runtime warning.
- *
- * Network calls to the VLINDER API (see src/store/app.ts) are intercepted
- * and served fixture data matching the real backend response shapes (see
- * src/tests/fixtures.ts). The topology file (public/belgium.topo.json) is
- * NOT intercepted - it's served as-is by vite preview from the real build,
- * so the map draws with the real, valid Belgium topology.
+ * Smoke test against the real production build in Chromium: real Vuetify
+ * CSS/components and real d3 rendering, with API calls served from fixtures.
  */
 
 function fulfillJson(route: Route, body: unknown) {
@@ -32,8 +21,6 @@ function fulfillJson(route: Route, body: unknown) {
 }
 
 test.beforeEach(async ({ page }) => {
-  // Intercept every call the store makes against the API (fetchStations,
-  // fetchMeasurements, and the per-station fetchHistoricMeasurements calls).
   await page.route('**/api/**', async (route) => {
     const url = new URL(route.request().url());
 
@@ -53,10 +40,7 @@ test.beforeEach(async ({ page }) => {
     return route.continue();
   });
 
-  // Stub the Google gtag loader with a harmless no-op script instead of
-  // letting it hit the real network (keeps the test deterministic/offline
-  // and avoids an unhandled-promise-rejection console error if the real
-  // request fails in a sandboxed CI runner).
+  // stub gtag so the run stays offline and deterministic
   await page.route('https://www.googletagmanager.com/gtag/js**', (route) =>
     route.fulfill({
       status: 200,
@@ -81,28 +65,22 @@ test('dashboard loads, renders station data and charts, with no console/page err
 
   await page.goto('/');
 
-  // The app bar and its title are part of the real Vuetify chrome.
   await expect(page.getByText('VLINDER', { exact: true }).first()).toBeVisible();
 
-  // Station data from the fixtures is visible - the default-selected
-  // stations (see src/store/app.ts) match the ids used in the fixtures.
+  // station data from the fixtures is visible
   await expect(page.getByText(stationsFixture[0].city, { exact: false }).first()).toBeVisible();
   await expect(page.getByText(stationsFixture[0].given_name, { exact: false }).first()).toBeVisible();
 
-  // Wait for the historic graphs to actually draw data (D3Graph redraws its
-  // line paths once historicMeasurements arrives), not just the shell.
+  // wait for the graphs to draw data, not just the shell
   await expect(page.locator('#weather_graph_temp path')).not.toHaveCount(0);
 
-  // Real d3-rendered SVGs are present: the stations map and at least one
-  // weather graph.
   const svgCount = await page.locator('svg').count();
   expect(svgCount).toBeGreaterThan(1);
 
   expect(await page.locator('#stationsMap svg').count()).toBeGreaterThan(0);
   expect(await page.locator('#weather_graph_temp svg').count()).toBeGreaterThan(0);
 
-  // Station markers were actually drawn on the map (real D3StationsMap,
-  // real belgium.topo.json, real fixture coordinates).
+  // station markers were actually drawn on the map
   await expect(page.locator('#stationsMap circle.station')).not.toHaveCount(0);
 
   expect(consoleErrors, `Unexpected console errors:\n${consoleErrors.join('\n')}`).toEqual([]);

--- a/dashboard/src/__tests__/app-smoke.spec.ts
+++ b/dashboard/src/__tests__/app-smoke.spec.ts
@@ -1,24 +1,8 @@
 /**
- * Warning-strict Vuetify smoke test.
- *
- * Unlike the per-component unit tests (which build a minimal local Vuetify
- * instance with an explicit component/directive list), this test mounts the
- * real App using the *real* Vuetify plugin instance from
- * src/plugins/vuetify.ts and the *real* router config from src/router, and
- * escalates every Vue runtime warning to a thrown error.
- *
- * That escalation is the whole point: an unknown-component warning (eg. a
- * renamed/removed Vuetify component after a major version bump) or an
- * invalid-prop-type warning would otherwise just print to the console and
- * the test would still pass. Here it fails the test instead, which is
- * exactly the kind of breakage a Vuetify 3->4 upgrade can introduce that
- * store/composable/d3-mocked component tests and vue-tsc cannot catch
- * (vue-tsc doesn't type-check template tag resolution against installed
- * Vuetify components, and it can't see runtime prop-shape mismatches).
- *
- * D3 rendering itself is intentionally still mocked out (as in the other
- * component tests) - the goal here is Vuetify component resolution, not
- * exercising d3-in-jsdom.
+ * Mounts the real App with the real Vuetify plugin and router, escalating
+ * every Vue runtime warning (unknown component, invalid prop, ...) to a
+ * thrown error - the failure mode of a Vuetify major bump that vue-tsc and
+ * the d3-mocked component tests cannot see.
  */
 import { mount, flushPromises } from '@vue/test-utils';
 import { describe, it, expect, vi, afterEach } from 'vitest';
@@ -37,16 +21,12 @@ import {
   topologyFixture,
 } from '../tests/fixtures';
 
-// Mock vue-gtag-next: main.ts installs it as a real plugin via app.use(),
-// but we mount App directly without going through main.ts, so useGtag()
-// would otherwise throw for lack of the injected gtag instance.
+// App is mounted without main.ts, which normally installs vue-gtag
 vi.mock('vue-gtag-next', () => ({
   useGtag: () => ({ event: vi.fn() }),
 }));
 
-// Mock the D3 wrapper classes, same as the existing per-component specs.
-// These touch the DOM directly with d3 selections in ways jsdom doesn't
-// need to fully support for a Vuetify-resolution smoke test.
+// mock the d3 wrappers, as in the per-component specs
 vi.mock('../app/d3/D3StationsMap', () => ({
   D3StationsMap: class {
     init = vi.fn();
@@ -78,8 +58,7 @@ function jsonResponse(body: unknown, ok = true) {
   } as Response);
 }
 
-// Realistic network mock: routes on the same URL shapes fetched by
-// src/store/app.ts and StationsMap.vue, matching the real API/static asset.
+// routes on the URL shapes fetched by the store and StationsMap.vue
 function installFetchMock() {
   vi.stubGlobal(
     'fetch',
@@ -144,9 +123,6 @@ describe('App smoke test (real Vuetify + real router + warning-strict)', () => {
       global: {
         plugins: [vuetify, pinia, router],
         config: {
-          // Escalate Vue runtime warnings (unknown components, invalid prop
-          // types/values, missing required props, ...) to thrown errors so
-          // this test fails loudly instead of just printing to console.
           warnHandler: (msg, _instance, trace) => {
             warnings.push(msg);
             throw new Error(`Vue warning escalated to failure: ${msg}\n${trace}`);
@@ -156,18 +132,14 @@ describe('App smoke test (real Vuetify + real router + warning-strict)', () => {
     });
 
     await router.isReady();
-    // Allow the lazily-imported layout/view chain and the store's async
-    // initialize()/fetchMeasurements()/fetchHistoricMeasurements() chain
-    // (which depends on watch(selectedStations) firing after initialize
-    // resolves) to settle.
+    // let the lazy view chain and the store's async init settle
     await flushPromises();
     await flushPromises();
     await flushPromises();
 
     expect(warnings).toEqual([]);
 
-    // Something meaningful actually rendered, not just "didn't crash":
-    // station data from the fixtures should be visible on the page.
+    // station data from the fixtures actually rendered
     const text = wrapper.text();
     expect(text).toContain(stationsFixture[0].city);
     expect(text).toContain(stationsFixture[0].given_name);

--- a/dashboard/src/store/app.ts
+++ b/dashboard/src/store/app.ts
@@ -5,9 +5,7 @@ const API_URL = import.meta.env.VITE_API_URL ?? 'https://mooncake.ugent.be/api';
 const STATIONS_PATH = '/stations';
 const MEASUREMENTS_PATH = '/measurements';
 
-// Incrementing token used to guard against overlapping fetchHistoricMeasurements calls
-// (eg. a station toggle firing while a poll is still in flight) overwriting fresher data
-// with a stale response.
+// guards overlapping fetchHistoricMeasurements calls from clobbering fresher data
 let historicMeasurementsRequestId = 0;
 
 export const useVlinderStore = defineStore('vlinder', {

--- a/dashboard/src/tests/fixtures.ts
+++ b/dashboard/src/tests/fixtures.ts
@@ -9,19 +9,14 @@
  */
 import type { Station, Measurement } from '../app/types';
 
-// The three station ids hardcoded as defaults in src/store/app.ts. These are
-// real, live station ids (vlinder02, and two others) so reusing them here
-// means the app's default-selection logic actually finds a match, exactly
-// like it would against the real API.
+// the default station ids hardcoded in src/store/app.ts, so default selection matches
 export const DEFAULT_STATION_IDS = [
   'zZ6ZeSg11dJ5zp5GrNwNck9A',
   'Do5lLMfezIdmUCzzsE0IwIbE',
   'XeIIA97QzN5xxk6AvdzAPquY',
 ] as const;
 
-// A station whose name does not start with "vlinder" (mirrors the real
-// MOCCA stations returned by the API), to exercise the filter in
-// D3StationsMap.ts that only plots "vlinder*" stations on the map.
+// a non-"vlinder" station, to exercise the map's vlinder*-only filter
 const MOCCA_STATION_ID = 'bas0provinciehuis000000';
 
 function landUse(waterBias: number) {


### PR DESCRIPTION
This pull request trims the multi-line explanatory comment blocks that recent PRs (#1294, #1298, #1299) introduced in `api/app.rb`, the api specs, and the dashboard test files down to the repo's usual sparse style: at most one short line where the code cannot speak for itself, nothing otherwise. 153 comment lines become 35.

Comment-only: the single non-comment change in the diff is a dropped trailing comment on an otherwise identical line, verified with `git diff -U0` filtered to non-comment lines.

Manual testing instructions: none needed beyond CI.

Verification: `ruby -c` on all three Ruby files; `yarn eslint .`, `yarn vitest run` (22/22), `yarn build`, and `yarn playwright test` (1/1) all pass.